### PR TITLE
Remove duplicate key from lock-threads config

### DIFF
--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -3,7 +3,6 @@
 # Number of days of inactivity before a closed issue or pull request is locked
 daysUntilLock: 180
 # Comment to post before locking. Set to `false` to disable
-lockComment: true
 lockComment: >
   This thread has been automatically locked because it has not had recent
   activity. Please open a new issue for related bugs and link to relevant


### PR DESCRIPTION
Noticed this exception in the bot logs.

```
[90m19:09:01.894Z[39m [31mERROR[39m Probot:

[90m  [36mduplicated mapping key at line 7, column -190:

      lockComment: >

      ^[39m

  --

  err: {

    "name": "YAMLException",

    "reason": "duplicated mapping key",

    "mark": {

      "name": null,

      "buffer": "# Configuration for lock-threads - https://github.com/dessant/lock-threads\n\n# Number of days of inactivity before a closed issue or pull request is locked\ndaysUntilLock: 180\n# Comment to post before locking. Set to `false` to disable\nlockComment: true\nlockComment: >\n  This thread has been automatically locked because it has not had recent\n  activity. Please open a new issue for related bugs and link to relevant\n  comments in this thread.\n\n# Limit to only `issues` or `pulls`\n# only: issues\n\u0000",

      "position": 252,

      "line": 6,

      "column": -191

    },

    "message": "duplicated mapping key at line 7, column -190:\n    lockComment: >\n    ^"

  }

  --

  event: {

    "event": "schedule",

    "action": "repository",

    "repository": "node-serialport/parsers"

  }
```